### PR TITLE
bitset fixes

### DIFF
--- a/kvm_mmu.c
+++ b/kvm_mmu.c
@@ -951,7 +951,7 @@ typedef struct kvm_mmu_pages {
 
 #define	for_each_unsync_children(bitmap, idx)		\
 	for (idx = bt_getlowbit(bitmap, 0, 512);	\
-	    idx < 512;					\
+	    (idx != -1) && (idx < 512);			\
 	    idx = bt_getlowbit(bitmap, idx+1, 512))
 
 static int
@@ -1006,7 +1006,7 @@ __mmu_unsync_walk(struct kvm_mmu_page *sp, struct kvm_mmu_pages *pvec,
 		}
 	}
 
-	if (bt_getlowbit(sp->unsync_child_bitmap, 0, 512) == 512)
+	if (bt_getlowbit(sp->unsync_child_bitmap, 0, 512) == -1)
 		sp->unsync_children = 0;
 
 	return (nr_unsync_leaf);

--- a/kvm_mmu.c
+++ b/kvm_mmu.c
@@ -950,9 +950,9 @@ typedef struct kvm_mmu_pages {
 } kvm_mmu_pages_t;
 
 #define	for_each_unsync_children(bitmap, idx)		\
-	for (idx = bt_getlowbit(bitmap, 0, 512);	\
+	for (idx = bt_getlowbit(bitmap, 0, 511);	\
 	    (idx != -1) && (idx < 512);			\
-	    idx = bt_getlowbit(bitmap, idx+1, 512))
+	    idx = bt_getlowbit(bitmap, idx+1, 511))
 
 static int
 mmu_pages_add(struct kvm_mmu_pages *pvec, struct kvm_mmu_page *sp, int idx)
@@ -1006,7 +1006,7 @@ __mmu_unsync_walk(struct kvm_mmu_page *sp, struct kvm_mmu_pages *pvec,
 		}
 	}
 
-	if (bt_getlowbit(sp->unsync_child_bitmap, 0, 512) == -1)
+	if (bt_getlowbit(sp->unsync_child_bitmap, 0, 511) == -1)
 		sp->unsync_children = 0;
 
 	return (nr_unsync_leaf);


### PR DESCRIPTION
as IRC, first changeset to stop us walking _massively_ out of bounds on spt, spinning indefinitely, or until we're unlucky enough to hit something nearly page-like, second to not search a bit too far.
