### PR TITLE
Let invlpg invlpg, walk hash list safely in get_page

### DIFF
--- a/kvm_emulate.c
+++ b/kvm_emulate.c
@@ -1874,11 +1874,7 @@ emulator_io_permited(struct x86_emulate_ctxt *ctxt,
 int
 emulate_invlpg(struct kvm_vcpu *vcpu, gva_t address)
 {
-#ifdef XXX
 	kvm_mmu_invlpg(vcpu, address);
-#else
-	XXX_KVM_PROBE;
-#endif
 	return (X86EMUL_CONTINUE);
 }
 

--- a/kvm_mmu.c
+++ b/kvm_mmu.c
@@ -1176,7 +1176,7 @@ kvm_mmu_get_page(struct kvm_vcpu *vcpu, gfn_t gfn, gva_t gaddr, unsigned level,
 	unsigned index;
 	unsigned quadrant;
 	list_t *bucket;
-	struct kvm_mmu_page *sp;
+	struct kvm_mmu_page *sp, *nsp = NULL;
 	struct hlist_node *node, *tmp;
 
 	role = vcpu->arch.mmu.base_role;
@@ -1193,8 +1193,8 @@ kvm_mmu_get_page(struct kvm_vcpu *vcpu, gfn_t gfn, gva_t gaddr, unsigned level,
 	index = kvm_page_table_hashfn(gfn);
 	bucket = &vcpu->kvm->arch.mmu_page_hash[index];
 
-	for (sp = list_head(bucket); sp != NULL;
-	    sp = list_next(bucket, sp)) {
+	for (sp = list_head(bucket); sp != NULL; sp = nsp) {
+		nsp = list_next(bucket, sp);
 		if (sp->gfn == gfn) {
 			if (sp->unsync)
 				if (kvm_sync_page(vcpu, sp))

--- a/tools/kvm-xxx.d
+++ b/tools/kvm-xxx.d
@@ -10,5 +10,5 @@ kvm-xxx
 tick-10sec
 {
 	printf("%-12s %-40s %-8s %8s\n", "FILE", "FUNCTION", "LINE", "COUNT");
-	printa("%20s %8d %@8d\n", @);
+	printa("%-12s %-40s %-8d %@8d\n", @);
 }


### PR DESCRIPTION
SunOS Release 5.11 Version joyent_20110813T221858Z 64-bit
Copyright (c) 2010-2011, Joyent Inc. All rights reserved.
trap: Unknown trap type 8 in user mode
WARNING: kvm: no hardware support

WARNING: rtls0: Failure resetting PHY.

```
         _____
      ____   ____
     _____   _____        .                   .
     __         __        | .-. .  . .-. :--. |-
     _____   _____        ;|   ||  |(.-' |  | |
      ____   ____     `--'  `-' `;-| `-' '  ' `-'
         _____                  /  ; Joyent Live Image v0.147+
                                `-'   build: 20110813T221858Z
```

52-54-00-12-34-56 ttya login:
